### PR TITLE
解决重复调用addsubview导致的crash问题

### DIFF
--- a/TBUIAutoTest/UIAutoLongPressGestureRecognizer.h
+++ b/TBUIAutoTest/UIAutoLongPressGestureRecognizer.h
@@ -1,0 +1,13 @@
+//
+//  UIAutoLongPressGestureRecognizer.h
+//  TBUIAutoTestDemo
+//
+//  Created by yanluojun on 2017/9/28.
+//  Copyright © 2017年 杨萧玉. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIAutoLongPressGestureRecognizer : UILongPressGestureRecognizer
+
+@end

--- a/TBUIAutoTest/UIAutoLongPressGestureRecognizer.m
+++ b/TBUIAutoTest/UIAutoLongPressGestureRecognizer.m
@@ -1,0 +1,13 @@
+//
+//  UIAutoLongPressGestureRecognizer.m
+//  TBUIAutoTestDemo
+//
+//  Created by yanluojun on 2017/9/28.
+//  Copyright © 2017年 杨萧玉. All rights reserved.
+//
+
+#import "UIAutoLongPressGestureRecognizer.h"
+
+@implementation UIAutoLongPressGestureRecognizer
+
+@end

--- a/TBUIAutoTest/UIView+TBUIAutoTest.m
+++ b/TBUIAutoTest/UIView+TBUIAutoTest.m
@@ -10,6 +10,7 @@
 #import "UIResponder+TBUIAutoTest.h"
 #import <objc/runtime.h>
 #import "TBUIAutoTest.h"
+#import "UIAutoLongPressGestureRecognizer.h"
 
 #define kiOS8Later SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")
 
@@ -150,7 +151,16 @@
         return;
     }
     [self tb_addSubview:view];
-    UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:view action:@selector(longPress:)];
+    
+    //已经add过了，防止重复add 手势
+    //- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+    //添加了多个subview之后 该delegate方法会被触发多次，导致奔溃
+    for (UIGestureRecognizer *ges in view.gestureRecognizers) {
+        if ([ges isKindOfClass:[UIAutoLongPressGestureRecognizer class]]) {
+            return ;
+        }
+    }
+    UIAutoLongPressGestureRecognizer *longPress = [[UIAutoLongPressGestureRecognizer alloc] initWithTarget:view action:@selector(longPress:)];
     longPress.delegate = [TBUIAutoTest sharedInstance];
     [view addGestureRecognizer:longPress];
 }

--- a/TBUIAutoTestDemo/TBUIAutoTestDemo.xcodeproj/project.pbxproj
+++ b/TBUIAutoTestDemo/TBUIAutoTestDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1BD958F71F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BD958F61F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.m */; };
 		A477FDCC1DD07657000F8482 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A477FDCB1DD07657000F8482 /* main.m */; };
 		A477FDCF1DD07657000F8482 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A477FDCE1DD07657000F8482 /* AppDelegate.m */; };
 		A477FDD21DD07657000F8482 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A477FDD11DD07657000F8482 /* ViewController.m */; };
@@ -52,6 +53,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1BD958F51F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIAutoLongPressGestureRecognizer.h; sourceTree = "<group>"; };
+		1BD958F61F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIAutoLongPressGestureRecognizer.m; sourceTree = "<group>"; };
 		A477FDC71DD07657000F8482 /* TBUIAutoTestDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TBUIAutoTestDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A477FDCB1DD07657000F8482 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		A477FDCD1DD07657000F8482 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -148,6 +151,8 @@
 				A477FDE71DD076B7000F8482 /* UIResponder+TBUIAutoTest.m */,
 				A477FDE81DD076B7000F8482 /* UIView+TBUIAutoTest.h */,
 				A477FDE91DD076B7000F8482 /* UIView+TBUIAutoTest.m */,
+				1BD958F51F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.h */,
+				1BD958F61F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.m */,
 			);
 			name = TBUIAutoTest;
 			path = ../../TBUIAutoTest;
@@ -279,6 +284,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1BD958F71F7C84DF001AF55B /* UIAutoLongPressGestureRecognizer.m in Sources */,
 				A477FDED1DD076B7000F8482 /* UIView+TBUIAutoTest.m in Sources */,
 				A477FDD21DD07657000F8482 /* ViewController.m in Sources */,
 				A477FDCF1DD07657000F8482 /* AppDelegate.m in Sources */,
@@ -520,6 +526,7 @@
 				A4FA505F1E751F4F0086DF0F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/TBUIAutoTestDemo/TBUIAutoTestDemo.xcodeproj/xcshareddata/xcschemes/TBUIAutoTestKit.xcscheme
+++ b/TBUIAutoTestDemo/TBUIAutoTestDemo.xcodeproj/xcshareddata/xcschemes/TBUIAutoTestKit.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A4FA50541E751F4F0086DF0F"
-               BuildableName = "TBUIAutoTestKit.framework"
+               BuildableName = "TBUIAutoTest.framework"
                BlueprintName = "TBUIAutoTestKit"
                ReferencedContainer = "container:TBUIAutoTestDemo.xcodeproj">
             </BuildableReference>
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -46,7 +48,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "A4FA50541E751F4F0086DF0F"
-            BuildableName = "TBUIAutoTestKit.framework"
+            BuildableName = "TBUIAutoTest.framework"
             BlueprintName = "TBUIAutoTestKit"
             ReferencedContainer = "container:TBUIAutoTestDemo.xcodeproj">
          </BuildableReference>
@@ -64,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "A4FA50541E751F4F0086DF0F"
-            BuildableName = "TBUIAutoTestKit.framework"
+            BuildableName = "TBUIAutoTest.framework"
             BlueprintName = "TBUIAutoTestKit"
             ReferencedContainer = "container:TBUIAutoTestDemo.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
如果对同一个view重复调用addsubview方法，在view的显示上 是不会有问题的，但是导致了重复添加手势的问题