### PR TITLE
hook UIView的方法  而不是其子类

### DIFF
--- a/TBUIAutoTest/UIImage+TBUIAutoTest.m
+++ b/TBUIAutoTest/UIImage+TBUIAutoTest.m
@@ -18,9 +18,10 @@
     {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            [object_getClass(self) swizzleSelector:@selector(imageNamed:) withAnotherSelector:@selector(tb_imageNamed:)];
-            [object_getClass(self) swizzleSelector:@selector(imageWithContentsOfFile:) withAnotherSelector:@selector(tb_imageWithContentsOfFile:)];
-            [self swizzleSelector:@selector(accessibilityIdentifier) withAnotherSelector:@selector(tb_accessibilityIdentifier)];
+            Class imageClass = NSClassFromString(@"UIImage");
+            [object_getClass(imageClass) swizzleSelector:@selector(imageNamed:) withAnotherSelector:@selector(tb_imageNamed:)];
+            [object_getClass(imageClass) swizzleSelector:@selector(imageWithContentsOfFile:) withAnotherSelector:@selector(tb_imageWithContentsOfFile:)];
+            [imageClass swizzleSelector:@selector(accessibilityIdentifier) withAnotherSelector:@selector(tb_accessibilityIdentifier)];
         });
     }
 }

--- a/TBUIAutoTest/UIView+TBUIAutoTest.m
+++ b/TBUIAutoTest/UIView+TBUIAutoTest.m
@@ -23,10 +23,11 @@
     {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            [self swizzleSelector:@selector(accessibilityIdentifier) withAnotherSelector:@selector(tb_accessibilityIdentifier)];
-            [self swizzleSelector:@selector(accessibilityLabel) withAnotherSelector:@selector(tb_accessibilityLabel)];
+            Class viewClass = NSClassFromString(@"UIView");
+            [viewClass swizzleSelector:@selector(accessibilityIdentifier) withAnotherSelector:@selector(tb_accessibilityIdentifier)];
+            [viewClass swizzleSelector:@selector(accessibilityLabel) withAnotherSelector:@selector(tb_accessibilityLabel)];
             if ([NSUserDefaults.standardUserDefaults boolForKey:kAutoTestUILongPressKey]) {
-                [self swizzleSelector:@selector(addSubview:) withAnotherSelector:@selector(tb_addSubview:)];
+                [viewClass swizzleSelector:@selector(addSubview:) withAnotherSelector:@selector(tb_addSubview:)];
             }
         });
     }


### PR DESCRIPTION
在`UIView (TBUIAutoTest)`分类交换方法时，不应该是
`[self swizzleSelector:@selector(accessibilityIdentifier) withAnotherSelector:@selector(tb_accessibilityIdentifier)];`，因为这时的self并不一定是UIView。

下面这样更保险一点：

`Class viewClass = NSClassFromString(@"UIView");
 [viewClass swizzleSelector:@selector(accessibilityIdentifier) withAnotherSelector:@selector(tb_accessibilityIdentifier)];`